### PR TITLE
TC-890: Add support for supplying more database details. This enables support for Aurora DB

### DIFF
--- a/rds-provisioning/main.tf
+++ b/rds-provisioning/main.tf
@@ -2,13 +2,21 @@
 # Invokes a lambda function to provision databases and roles to an RDS instance
 ####################################################################################
 
+locals {
+  database_address = var.rds_instance_id != null ? data.aws_db_instance.rds[0].address : var.address
+  port = var.rds_instance_id != null ? data.aws_db_instance.rds[0].port : var.port
+  master_username = var.rds_instance_id != null ? data.aws_db_instance.rds[0].master_username : var.master_username
+}
+
 # Get RDS instance
 data "aws_db_instance" rds {
+  count = var.rds_instance_id != null ? 1 : 0
   db_instance_identifier = var.rds_instance_id
 }
 
 # Get master password for RDS from SSM
 data "aws_ssm_parameter" rds_master_password {
+  count = var.rds_instance_id != null ? 1 : 0
   name = "${var.rds_instance_id}-rds-master-password"
 }
 
@@ -17,13 +25,13 @@ data "aws_lambda_invocation" "lambda_invocation" {
   function_name = "${var.name_prefix}-rds-provisioning"
   input = <<JSON
   {
-    "master_username" : "${data.aws_db_instance.rds.master_username}",
+    "master_username" : "${local.master_username}",
     "master_password" : "${data.aws_ssm_parameter.rds_master_password.value}",
     "database" : "${var.database}",
     "username" : "${var.username}",
     "password" : "${var.password}",
-    "address" : "${data.aws_db_instance.rds.address}",
-    "port" : "${data.aws_db_instance.rds.port}"
+    "address" : "${local.database_address}",
+    "port" : "${local.port}"
   }
   JSON
 }

--- a/rds-provisioning/main.tf
+++ b/rds-provisioning/main.tf
@@ -3,9 +3,10 @@
 ####################################################################################
 
 locals {
-  database_address = var.rds_instance_id != null ? data.aws_db_instance.rds[0].address : var.address
   port = var.rds_instance_id != null ? data.aws_db_instance.rds[0].port : var.port
+  database_address = var.rds_instance_id != null ? data.aws_db_instance.rds[0].address : var.address
   master_username = var.rds_instance_id != null ? data.aws_db_instance.rds[0].master_username : var.master_username
+  master_password = var.rds_instance_id != null ? data.aws_db_instance.rds[0].master_username : var.master_password
 }
 
 # Get RDS instance
@@ -26,7 +27,7 @@ data "aws_lambda_invocation" "lambda_invocation" {
   input = <<JSON
   {
     "master_username" : "${local.master_username}",
-    "master_password" : "${data.aws_ssm_parameter.rds_master_password.value}",
+    "master_password" : "${local.master_password}",
     "database" : "${var.database}",
     "username" : "${var.username}",
     "password" : "${var.password}",

--- a/rds-provisioning/main.tf
+++ b/rds-provisioning/main.tf
@@ -6,7 +6,7 @@ locals {
   port = var.rds_instance_id != null ? data.aws_db_instance.rds[0].port : var.port
   database_address = var.rds_instance_id != null ? data.aws_db_instance.rds[0].address : var.address
   master_username = var.rds_instance_id != null ? data.aws_db_instance.rds[0].master_username : var.master_username
-  master_password = var.rds_instance_id != null ? data.aws_db_instance.rds[0].master_username : var.master_password
+  master_password = var.rds_instance_id != null ? data.aws_ssm_parameter.rds_master_password[0].value : var.master_password
 }
 
 # Get RDS instance

--- a/rds-provisioning/outputs.tf
+++ b/rds-provisioning/outputs.tf
@@ -1,6 +1,6 @@
 output "endpoint" {
   description = "Endpoint to RDS"
-  value       = data.aws_db_instance.rds.endpoint
+  value       = local.database_address
 }
 
 output "database" {

--- a/rds-provisioning/variables.tf
+++ b/rds-provisioning/variables.tf
@@ -22,3 +22,18 @@ variable "password" {
   type = string
   description = "Password for database user"
 }
+
+variable "master_username" {
+  type = string
+  description = "Database master username"
+}
+
+variable "address" {
+  type = string
+  description = "The address for database"
+}
+
+variable "port" {
+  type = string
+  description = "The port for the database"
+}

--- a/rds-provisioning/variables.tf
+++ b/rds-provisioning/variables.tf
@@ -41,10 +41,12 @@ variable "master_username" {
   type = string
   description = "Database master username"
   default = ""
+  sensitive = true
 }
 
 variable "master_password" {
   type = string
   description = "Database master password"
   default = ""
+  sensitive = true
 }

--- a/rds-provisioning/variables.tf
+++ b/rds-provisioning/variables.tf
@@ -6,6 +6,7 @@ variable "name_prefix" {
 variable "rds_instance_id" {
   type = string
   description = "RDS instance identifier"
+  default = null
 }
 
 variable "database" {
@@ -23,17 +24,27 @@ variable "password" {
   description = "Password for database user"
 }
 
-variable "master_username" {
-  type = string
-  description = "Database master username"
-}
 
 variable "address" {
   type = string
   description = "The address for database"
+  default = ""
 }
 
 variable "port" {
   type = string
   description = "The port for the database"
+  default = ""
+}
+
+variable "master_username" {
+  type = string
+  description = "Database master username"
+  default = ""
+}
+
+variable "master_password" {
+  type = string
+  description = "Database master password"
+  default = ""
 }


### PR DESCRIPTION
Jira: https://vygruppen.atlassian.net/browse/TCONTROL-980


Ønsker å utvide modulen til å støtte databaser som ikke er spunnet opp som en `aws_db_instance`. Gjør det ved å åpne for å supplere inn verdiene som hentes ut av `data.aws_db_instance` som variabler

Implementasjon fra Opinfo-train
```
resource "random_password" "opinfo_train_rds_password" {
  length  = 25
  special = false
}

module opinfo_database {
  source = "github.com/nsbno/terraform-aws-trafficcontrol?ref=da1c48c/rds-provisioning"
  name_prefix = var.name_prefix

  database = data.aws_rds_cluster.opinfo_rds_cluster.database_name
  username = "opinfotrain"
  password = random_password.opinfo_train_rds_password.result
  master_username = data.aws_rds_cluster.opinfo_rds_cluster.master_username
  master_password = data.aws_ssm_parameter.rds_master_password.value
  port = data.aws_rds_cluster.opinfo_rds_cluster.port
  database_address = data.aws_rds_cluster.opinfo_rds_cluster.endpoint
}

data "aws_rds_cluster" opinfo_rds_cluster {
  cluster_identifier = "operational-information"
}

data "aws_ssm_parameter" rds_master_password {
  name = "operationalinformation-rds-master-password"
}
```