### PR TITLE
Add subscription toggle variable

### DIFF
--- a/sns-topic-subscription/main.tf
+++ b/sns-topic-subscription/main.tf
@@ -17,6 +17,7 @@ resource "aws_sns_topic_subscription" "topic_subscription" {
   raw_message_delivery = true
   topic_arn            = var.sns_topic_arn
   filter_policy        = length(var.filter_policy) > 0 ? var.filter_policy : null
+  count                = var.enable_subscription ? 1 : 0
 }
 
 data "aws_iam_policy_document" "iam_policy_document" {

--- a/sns-topic-subscription/variables.tf
+++ b/sns-topic-subscription/variables.tf
@@ -39,6 +39,11 @@ variable "max_receive_count" {
   default = 3
 }
 
+variable "enable_subscription" {
+  type    = bool
+  default = true
+}
+
 variable "sns_topic_arn" {
   type = string
 }


### PR DESCRIPTION
Add an option for "disabling" (removing) the SNS subscription.

The need arose when not all environments had a corresponding source SNS, but we did not want to delete the SQS, as it is in use elsewhere.

This change technically makes the subscription resource a list of resources. However, existing module instances do not appear to need replacing, and because the subscription is not referred to elsewhere in the module nor exposed as an output, it should not affect surrounding infrastructure either.