### PR TITLE
TCONTROL-1441: Add S3-bucket for large SNS messages

### DIFF
--- a/sns-topic/outputs.tf
+++ b/sns-topic/outputs.tf
@@ -7,3 +7,13 @@ output "topicId" {
   description = "The Amazon SNS Id created in this module"
   value = aws_sns_topic.sns_topic.id
 }
+
+output "bucketId" {
+  description = "The S3-bucket ID created in this module."
+  value = aws_s3_bucket.large_message_payload.id
+}
+
+output "bucketArn" {
+  description = "The S3-bucket ARN created in this module."
+  value = aws_s3_bucket.large_message_payload.arn
+}

--- a/sns-topic/variables.tf
+++ b/sns-topic/variables.tf
@@ -18,3 +18,13 @@ variable "external_subscribers" {
   description = "A list of account numbers that are allowed to create topic subscriptions"
   type        = list(string)
 }
+
+variable "create_payload_bucket" {
+  description = "Whether to create an S3-bucket for large messages."
+  type = bool
+}
+
+variable "payload_bucket_name" {
+  description = "Name of the SNS payload S3-bucket."
+  type = string
+}


### PR DESCRIPTION
Adds optional resources to create an S3 bucket for large SNS message payloads. Configures read access to the S3-bucket for external subscribers.