### PR TITLE
Access specific instance of optional s3 payload bucket

### DIFF
--- a/sns-topic/main.tf
+++ b/sns-topic/main.tf
@@ -77,8 +77,8 @@ data "aws_iam_policy_document" "allow_external_read" {
     ]
 
     resources = [
-      aws_s3_bucket.large_message_payload.arn,
-      "${aws_s3_bucket.large_message_payload.arn}/*",
+      aws_s3_bucket.large_message_payload[0].arn,
+      "${aws_s3_bucket.large_message_payload[0].arn}/*",
     ]
   }
 }

--- a/sns-topic/outputs.tf
+++ b/sns-topic/outputs.tf
@@ -10,10 +10,10 @@ output "topicId" {
 
 output "bucketId" {
   description = "The S3-bucket ID created in this module."
-  value = aws_s3_bucket.large_message_payload.id
+  value = aws_s3_bucket.large_message_payload[0].id
 }
 
 output "bucketArn" {
   description = "The S3-bucket ARN created in this module."
-  value = aws_s3_bucket.large_message_payload.arn
+  value = aws_s3_bucket.large_message_payload[0].arn
 }


### PR DESCRIPTION
Modulen feiler ettersom S3 bøtten er optional og må aksesserer som en liste.