### PR TITLE
Add support for custom DLQ message retention

### DIFF
--- a/sns-topic-subscription/main.tf
+++ b/sns-topic-subscription/main.tf
@@ -1,14 +1,15 @@
 module "sqs_queue" {
-  source = "../sqs-queue"
-  queue_name = var.queue_name
-  delay_seconds = var.delay_seconds
-  max_message_size           = var.max_message_size
-  message_retention_seconds  = var.message_retention_seconds
-  receive_wait_time_seconds  = var.receive_wait_time_seconds
-  visibility_timeout_seconds = var.visibility_timeout_seconds
-  fifo_queue                 = var.fifo_queue
-  tags                       = var.tags
-  enable_dlq = var.enable_dlq
+  source                        = "../sqs-queue"
+  queue_name                    = var.queue_name
+  delay_seconds                 = var.delay_seconds
+  max_message_size              = var.max_message_size
+  message_retention_seconds     = var.message_retention_seconds
+  message_retention_seconds_dlq = var.message_retention_seconds_dlq
+  receive_wait_time_seconds     = var.receive_wait_time_seconds
+  visibility_timeout_seconds    = var.visibility_timeout_seconds
+  fifo_queue                    = var.fifo_queue
+  tags                          = var.tags
+  enable_dlq                    = var.enable_dlq
 }
 
 resource "aws_sns_topic_subscription" "topic_subscription" {

--- a/sns-topic-subscription/variables.tf
+++ b/sns-topic-subscription/variables.tf
@@ -18,7 +18,6 @@ variable "message_retention_seconds" {
 }
 variable "message_retention_seconds_dlq" {
   type    = number
-  default = -1
 }
 variable "receive_wait_time_seconds" {
   type    = number

--- a/sns-topic-subscription/variables.tf
+++ b/sns-topic-subscription/variables.tf
@@ -18,6 +18,7 @@ variable "message_retention_seconds" {
 }
 variable "message_retention_seconds_dlq" {
   type    = number
+  default = null
 }
 variable "receive_wait_time_seconds" {
   type    = number

--- a/sns-topic-subscription/variables.tf
+++ b/sns-topic-subscription/variables.tf
@@ -16,6 +16,10 @@ variable "message_retention_seconds" {
   type    = number
   default = 86400
 }
+variable "message_retention_seconds_dlq" {
+  type    = number
+  default = -1
+}
 variable "receive_wait_time_seconds" {
   type    = number
   default = 20

--- a/sqs-queue/main.tf
+++ b/sqs-queue/main.tf
@@ -21,6 +21,6 @@ resource "aws_sqs_queue" "sqs_queue_dlq" {
   receive_wait_time_seconds  = var.receive_wait_time_seconds
   visibility_timeout_seconds = var.visibility_timeout_seconds
   fifo_queue                 = var.fifo_queue
-  message_retention_seconds  = var.message_retention_seconds_dlq
+  message_retention_seconds  = coalesce(var.message_retention_seconds_dlq, var.message_retention_seconds * 10)
   tags                       = var.tags
 }

--- a/sqs-queue/main.tf
+++ b/sqs-queue/main.tf
@@ -21,6 +21,6 @@ resource "aws_sqs_queue" "sqs_queue_dlq" {
   receive_wait_time_seconds  = var.receive_wait_time_seconds
   visibility_timeout_seconds = var.visibility_timeout_seconds
   fifo_queue                 = var.fifo_queue
-  message_retention_seconds  = var.message_retention_seconds_dlq != -1 ? var.message_retention_seconds_dlq : var.message_retention_seconds * 10
+  message_retention_seconds  = var.message_retention_seconds_dlq
   tags                       = var.tags
 }

--- a/sqs-queue/main.tf
+++ b/sqs-queue/main.tf
@@ -21,6 +21,6 @@ resource "aws_sqs_queue" "sqs_queue_dlq" {
   receive_wait_time_seconds  = var.receive_wait_time_seconds
   visibility_timeout_seconds = var.visibility_timeout_seconds
   fifo_queue                 = var.fifo_queue
-  message_retention_seconds  = var.message_retention_seconds * 10
+  message_retention_seconds  = var.message_retention_seconds_dlq != -1 ? var.message_retention_seconds_dlq : var.message_retention_seconds * 10
   tags                       = var.tags
 }

--- a/sqs-queue/variables.tf
+++ b/sqs-queue/variables.tf
@@ -14,6 +14,7 @@ variable "message_retention_seconds" {
 }
 variable "message_retention_seconds_dlq" {
   type    = number
+  default = null
 }
 variable "receive_wait_time_seconds" {
   type    = number

--- a/sqs-queue/variables.tf
+++ b/sqs-queue/variables.tf
@@ -14,7 +14,6 @@ variable "message_retention_seconds" {
 }
 variable "message_retention_seconds_dlq" {
   type    = number
-  default = -1
 }
 variable "receive_wait_time_seconds" {
   type    = number

--- a/sqs-queue/variables.tf
+++ b/sqs-queue/variables.tf
@@ -12,6 +12,10 @@ variable "message_retention_seconds" {
   type    = number
   default = 86400
 }
+variable "message_retention_seconds_dlq" {
+  type    = number
+  default = -1
+}
 variable "receive_wait_time_seconds" {
   type    = number
   default = 20


### PR DESCRIPTION
The SQS module has a set factor of 10 between the message retention periods of the primary queue and the dead letter queue, which is not always the desired ratio.

This change allows the message retention period to be specified for DLQ in the SQS module (and the SNS subscription module that uses it). The implementation is backwards compatible by using `-1` as a default variable value, and in turn substituting that with 10x the primary SQS message retention time, unless specified when using the module.