### PR TITLE
Expose DLQ attributes as outputs from sns-topic-subscription

### DIFF
--- a/sns-topic-subscription/outputs.tf
+++ b/sns-topic-subscription/outputs.tf
@@ -12,3 +12,18 @@ output "sqs_queue_name" {
   description = "The Amazon SQS name created in this module"
   value       = module.sqs_queue.sqs_queue_name
 }
+
+output "sqs_queue_dlq_arn" {
+  description = "The Amazon SQS DLQ arn created in this module"
+  value       = module.sqs_queue.sqs_queue_dlq_arn
+}
+
+output "sqs_queue_dlq_id" {
+  description = "The Amazon SQS DLQ id created in this module"
+  value       = module.sqs_queue.sqs_queue_dlq_id
+}
+
+output "sqs_queue_dlq_name" {
+  description = "The Amazon SQS DLQ name created in this module"
+  value       = module.sqs_queue.sqs_queue_dlq_name
+}


### PR DESCRIPTION
The `sns-topic-subscription` module with dlq enabled creates a second resource (queue) which is not made available from outside the module.

This change makes it possible to reference the DLQ created by this module without making hacky assumptions (such as appending "-DLQ" to the end of the name or arn like [this](https://github.com/nsbno/digitalekanaler-cxm-proxy/blob/e25313b3e9afc191ec89b78518a96ace3d14793b/terraform/template/main.tf#L251)), in the same way its done in the `sqs-queue` module.